### PR TITLE
Fix stack builds

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,4 @@
 resolver: lts-11.9
-allow-newer: true
+
+extra-deps:
+  - dhall-1.14.0


### PR DESCRIPTION
Turns out that to `stack`, `allow-newer` means "ignore all version constraints and build anyway". This means that any `stack build`s of `dhall-text` will build against whatever version of `dhall` is in the specified resolver, currently `1.11.1`.

While this cocktail of packages happens to build successfully, it's still an old version of dhall, and will fail to properly evaluate newer dhall programs. The fix is just to specify the exact version of `dhall` you want in the `extra-deps` field of `stack.yaml`.

This obviously isn't ideal, as it'll have to be updated along with the cabal file and/or as new versions of dhall make it into `lts` distributions. Still, I got bit by this, and it seems worth the tiny bit of effort to help others building with `stack` avoid it, at least in the short term.