### PR TITLE
Use a newer version of Nixpkgs

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -2,11 +2,11 @@ let
   fetchNixpkgs = import ./nix/fetchNixpkgs.nix;
 
   nixpkgs = fetchNixpkgs {
-    rev = "804060ff9a79ceb0925fe9ef79ddbf564a225d47";
+    rev = "1d4de0d552ae9aa66a5b8dee5fb0650a4372d148";
 
-    sha256 = "01pb6p07xawi60kshsxxq1bzn8a0y4s5jjqvhkwps4f5xjmmwav3";
+    sha256 = "09qx58dp1kbj7cpzp8ahbqfbbab1frb12sh1qng87rybcaz0dz01";
 
-    outputSha256 = "0ga345hgw6v2kzyhvf5kw96hf60mx5pbd9c4qj5q4nan4lr7nkxn";
+    outputSha256 = "0xpqc1fhkvvv5dv1zmas2j1q27mi7j7dgyjcdh82mlgl1q63i660";
   };
 
   config = {
@@ -20,10 +20,6 @@ let
               (pkgs.haskell.lib.justStaticExecutables
                 (haskellPackagesNew.callPackage ./nix/dhall-text.nix { })
               );
-
-          formatting = haskellPackagesOld.formatting_6_3_0;
-
-          prettyprinter = haskellPackagesOld.prettyprinter_1_2_0_1;
         };
       };
     };


### PR DESCRIPTION
The `dhall` dependency was failing to build with the older version of
Nixpkgs on OS X due to https://github.com/NixOS/nixpkgs/issues/41340.  The newer
version of Nixpkgs fixes the problem